### PR TITLE
#175 - API application URL fragment updates

### DIFF
--- a/org.eclipse.kapua.app.api/pom.xml
+++ b/org.eclipse.kapua.app.api/pom.xml
@@ -132,7 +132,7 @@
 		
 	</dependencies>
 	<build>
-		<finalName>kapua</finalName>
+		<finalName>api</finalName>
 		<plugins>
 		</plugins>
 	</build>

--- a/org.eclipse.kapua.app.api/src/main/resources/shiro.ini
+++ b/org.eclipse.kapua.app.api/src/main/resources/shiro.ini
@@ -38,10 +38,10 @@ securityManager.rememberMeManager.cookie.maxAge = 0
 # The 'urls' section is used for url-based security
 # in web applications.  We'll discuss this section in the
 # Web documentation
-/api/v1/test                = kapuaAuthcBasic, noSessionCreation
-/api/v1/accounts.xml        = kapuaAuthcBasic, noSessionCreation
-/api/v1/accounts.json       = kapuaAuthcBasic, noSessionCreation
-/api/v1/accounts/**         = kapuaAuthcBasic, noSessionCreation
-/api/v1/users.json          = kapuaAuthcBasic, noSessionCreation
-/api/v1/users.xml           = kapuaAuthcBasic, noSessionCreation
-/api/v1/users/**            = kapuaAuthcBasic, noSessionCreation
+/v1/test                = kapuaAuthcBasic, noSessionCreation
+/v1/accounts.xml        = kapuaAuthcBasic, noSessionCreation
+/v1/accounts.json       = kapuaAuthcBasic, noSessionCreation
+/v1/accounts/**         = kapuaAuthcBasic, noSessionCreation
+/v1/users.json          = kapuaAuthcBasic, noSessionCreation
+/v1/users.xml           = kapuaAuthcBasic, noSessionCreation
+/v1/users/**            = kapuaAuthcBasic, noSessionCreation

--- a/org.eclipse.kapua.app.api/src/main/webapp/WEB-INF/web.xml
+++ b/org.eclipse.kapua.app.api/src/main/webapp/WEB-INF/web.xml
@@ -19,7 +19,7 @@
 	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
 	id="WebApp_ID" version="3.0">
 
-	<display-name>api</display-name>
+	<display-name>Kapua REST API</display-name>
 
 	<!-- -->
 	<!-- Filters -->   	
@@ -61,7 +61,7 @@
 	</servlet>
 	<servlet-mapping>
 		<servlet-name>Jersey Web Application</servlet-name>
-		<url-pattern>/api/v1/*</url-pattern>
+		<url-pattern>/v1/*</url-pattern>
 	</servlet-mapping>
 
 	<servlet>
@@ -73,7 +73,7 @@
 		</init-param>
 		<init-param>
 			<param-name>swagger.api.basepath</param-name>
-			<param-value>http://localhost:8080/kapua/api/v1/</param-value>
+			<param-value>http://localhost:8080/api/v1/</param-value>
 		</init-param>
 		<load-on-startup>2</load-on-startup>
 	</servlet>


### PR DESCRIPTION
Renaming the URL fragment of Kapua API to “api”, fixing #175. Also remaps Shiro URLs and Swagger base URL